### PR TITLE
call top level ActiveSupport module

### DIFF
--- a/lib/puff/instrumentation/redis.rb
+++ b/lib/puff/instrumentation/redis.rb
@@ -5,7 +5,7 @@ class Redis
     alias :old_logging :logging
 
     def logging(commands, &block)
-      ActiveSupport::Notifications.instrument('request.redis', commands: commands) do
+      ::ActiveSupport::Notifications.instrument('request.redis', commands: commands) do
         return old_logging(commands, &block)
       end
     end


### PR DESCRIPTION
otherwise it fails with:

```
/Users/troex/.bundle/gems/puff-0.3.0/lib/puff/Instrumentation/redis.rb:8:in `logging': uninitialized constant Redis::ActiveSupport::Notifications (NameError)
```

Rails 3.2.12, Ruby 1.9.3p448

Nice instrumentation hack, I like it!
